### PR TITLE
Фикс отступов в списках. Поддержка двух версий сборщика???

### DIFF
--- a/_themes/sphinx_rtd_theme_upgraded/static/css/theme.css
+++ b/_themes/sphinx_rtd_theme_upgraded/static/css/theme.css
@@ -5655,9 +5655,11 @@ article ul {
 	margin-bottom: 24px
 }
 
+.rst-content .section ul li,
 .rst-content section ul li,
 .rst-content .toctree-wrapper ul li,
 .wy-plain-list-disc li,
+.article ul li,
 article ul li {
 	list-style: disc;
 	margin-left: 24px;


### PR DESCRIPTION
Поправил отступы в списках, добавил тэги в css под разные верстки (обнаружил, что мой локальный билдер и на сайте отличаются, создаются разные классы у некоторых блоков)